### PR TITLE
GH-7 Release 1.1.1 hotfix.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>pl.mrstudios.deathrun</groupId>
         <artifactId>deathrun-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
     <artifactId>deathrun-api</artifactId>

--- a/api/src/main/java/pl/mrstudios/deathrun/api/arena/booster/IBoosterItem.java
+++ b/api/src/main/java/pl/mrstudios/deathrun/api/arena/booster/IBoosterItem.java
@@ -2,8 +2,10 @@ package pl.mrstudios.deathrun.api.arena.booster;
 
 import org.bukkit.Material;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public interface IBoosterItem {
     @NotNull String name();
     @NotNull Material material();
+    @Nullable String texture();
 }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>pl.mrstudios.deathrun</groupId>
         <artifactId>deathrun-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
     <artifactId>deathrun-core</artifactId>

--- a/core/src/main/java/pl/mrstudios/deathrun/arena/ArenaServiceRunnable.java
+++ b/core/src/main/java/pl/mrstudios/deathrun/arena/ArenaServiceRunnable.java
@@ -9,6 +9,7 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Server;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemFlag;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -248,6 +249,8 @@ public class ArenaServiceRunnable extends BukkitRunnable {
                                         player.getInventory().setItem(
                                                 booster.slot(), new ItemBuilder(booster.item().material())
                                                         .name(booster.item().name())
+                                                        .texture(booster.item().texture())
+                                                        .itemFlag(ItemFlag.values())
                                                         .build()
                                         ));
 

--- a/core/src/main/java/pl/mrstudios/deathrun/arena/booster/BoosterItem.java
+++ b/core/src/main/java/pl/mrstudios/deathrun/arena/booster/BoosterItem.java
@@ -2,9 +2,11 @@ package pl.mrstudios.deathrun.arena.booster;
 
 import org.bukkit.Material;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import pl.mrstudios.deathrun.api.arena.booster.IBoosterItem;
 
 public record BoosterItem(
         @NotNull String name,
-        @NotNull Material material
+        @NotNull Material material,
+        @Nullable String texture
 ) implements IBoosterItem {}

--- a/core/src/main/java/pl/mrstudios/deathrun/arena/listener/ArenaBoosterListener.java
+++ b/core/src/main/java/pl/mrstudios/deathrun/arena/listener/ArenaBoosterListener.java
@@ -82,13 +82,13 @@ public class ArenaBoosterListener implements Listener {
 
                                 event.getPlayer().getInventory().setItem(
                                         booster.slot(),
-                                        new ItemBuilder(booster.delayItem().material())
+                                        new ItemBuilder(booster.delayItem().material(), boosterDelay)
                                                 .name(booster.delayItem().name().replace("<delay>", String.valueOf(boosterDelay)))
                                                 .itemFlag(ItemFlag.values())
                                                 .build()
                                 );
 
-                                if (boosterDelay > 0)
+                                if (boosterDelay > 1)
                                     return;
 
                                 event.getPlayer().getInventory().setItem(

--- a/core/src/main/java/pl/mrstudios/deathrun/arena/listener/ArenaBoosterListener.java
+++ b/core/src/main/java/pl/mrstudios/deathrun/arena/listener/ArenaBoosterListener.java
@@ -10,6 +10,7 @@ import org.bukkit.inventory.ItemFlag;
 import org.bukkit.plugin.Plugin;
 import pl.mrstudios.commons.inject.annotation.Inject;
 import pl.mrstudios.deathrun.api.arena.booster.IBooster;
+import pl.mrstudios.deathrun.api.arena.enums.GameState;
 import pl.mrstudios.deathrun.api.arena.event.user.UserArenaUseBoosterEvent;
 import pl.mrstudios.deathrun.api.arena.user.IUser;
 import pl.mrstudios.deathrun.arena.Arena;
@@ -77,6 +78,14 @@ public class ArenaBoosterListener implements Listener {
 
                     taskId.set(
                             this.server.getScheduler().scheduleSyncRepeatingTask(this.plugin, () -> {
+
+                                if (this.arena.getGameState() != GameState.PLAYING)
+                                    this.configuration.plugin().boosters
+                                            .forEach((object) -> event.getPlayer().getInventory().setItem(object.slot(), null));
+
+                                if (this.arena.getGameState() != GameState.PLAYING)
+                                    if (taskId.get() != -1)
+                                        this.server.getScheduler().cancelTask(taskId.get());
 
                                 int boosterDelay = (int) (this.delay.get(event.getPlayer().getName()).get(booster) - System.currentTimeMillis()) / 1000;
 

--- a/core/src/main/java/pl/mrstudios/deathrun/arena/listener/ArenaBoosterListener.java
+++ b/core/src/main/java/pl/mrstudios/deathrun/arena/listener/ArenaBoosterListener.java
@@ -1,6 +1,5 @@
 package pl.mrstudios.deathrun.arena.listener;
 
-import org.bukkit.Material;
 import org.bukkit.Server;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -8,7 +7,6 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemFlag;
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
 import pl.mrstudios.commons.inject.annotation.Inject;
 import pl.mrstudios.deathrun.api.arena.booster.IBooster;
@@ -51,7 +49,9 @@ public class ArenaBoosterListener implements Listener {
 
         this.configuration.plugin().boosters
                 .stream()
-                .filter((booster) -> booster.item().material() == event.getPlayer().getItemInHand().getType())
+                .filter((booster) -> event.getPlayer().getInventory().getItem(booster.slot()) != null)
+                .filter((booster) -> event.getPlayer().getInventory().getItem(booster.slot()).getType() == booster.item().material())
+                .filter((booster) -> booster.slot() == event.getPlayer().getInventory().getHeldItemSlot())
                 .findFirst()
                 .ifPresent((booster) -> {
 

--- a/core/src/main/java/pl/mrstudios/deathrun/arena/listener/ArenaBoosterListener.java
+++ b/core/src/main/java/pl/mrstudios/deathrun/arena/listener/ArenaBoosterListener.java
@@ -84,17 +84,19 @@ public class ArenaBoosterListener implements Listener {
                                         booster.slot(),
                                         new ItemBuilder(booster.delayItem().material(), boosterDelay)
                                                 .name(booster.delayItem().name().replace("<delay>", String.valueOf(boosterDelay)))
+                                                .texture(booster.delayItem().texture())
                                                 .itemFlag(ItemFlag.values())
                                                 .build()
                                 );
 
-                                if (boosterDelay > 1)
+                                if (boosterDelay >= 1)
                                     return;
 
                                 event.getPlayer().getInventory().setItem(
                                         booster.slot(),
                                         new ItemBuilder(booster.item().material())
                                                 .name(booster.item().name())
+                                                .texture(booster.item().texture())
                                                 .itemFlag(ItemFlag.values())
                                                 .build()
                                 );

--- a/core/src/main/java/pl/mrstudios/deathrun/arena/listener/ArenaBoosterListener.java
+++ b/core/src/main/java/pl/mrstudios/deathrun/arena/listener/ArenaBoosterListener.java
@@ -1,5 +1,6 @@
 package pl.mrstudios.deathrun.arena.listener;
 
+import org.bukkit.Material;
 import org.bukkit.Server;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -7,6 +8,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
 import pl.mrstudios.commons.inject.annotation.Inject;
 import pl.mrstudios.deathrun.api.arena.booster.IBooster;
@@ -86,6 +88,9 @@ public class ArenaBoosterListener implements Listener {
                                 if (this.arena.getGameState() != GameState.PLAYING)
                                     if (taskId.get() != -1)
                                         this.server.getScheduler().cancelTask(taskId.get());
+
+                                if (this.arena.getGameState() != GameState.PLAYING)
+                                    return;
 
                                 int boosterDelay = (int) (this.delay.get(event.getPlayer().getName()).get(booster) - System.currentTimeMillis()) / 1000;
 

--- a/core/src/main/java/pl/mrstudios/deathrun/arena/trap/impl/TrapAppearingBlocks.java
+++ b/core/src/main/java/pl/mrstudios/deathrun/arena/trap/impl/TrapAppearingBlocks.java
@@ -6,6 +6,7 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.data.BlockData;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import pl.mrstudios.deathrun.api.arena.trap.annotations.Serializable;
 import pl.mrstudios.deathrun.arena.trap.Trap;
 
@@ -45,14 +46,27 @@ public class TrapAppearingBlocks extends Trap {
         if (objects.length == 0)
             return;
 
-        if (objects[0] instanceof Material extraMaterial)
-            this.material = extraMaterial;
+        if (objects[0] instanceof Material fillableMaterial)
+            this.material = fillableMaterial;
 
     }
 
     @Override
-    public @NotNull List<Location> filter(@NotNull List<Location> list, Object... objects) {
-        return list;
+    public @NotNull List<Location> filter(@NotNull List<Location> list, @Nullable Object... objects) {
+
+        if (objects == null)
+            return list;
+
+        if (objects.length == 2)
+            return list;
+
+        if (!(objects[1] instanceof Material filterMaterial))
+            return list;
+
+        return list.stream()
+                .filter((location) -> location.getBlock().getType() == filterMaterial)
+                .toList();
+
     }
 
     @Override

--- a/core/src/main/java/pl/mrstudios/deathrun/arena/trap/impl/TrapAppearingBlocks.java
+++ b/core/src/main/java/pl/mrstudios/deathrun/arena/trap/impl/TrapAppearingBlocks.java
@@ -53,20 +53,7 @@ public class TrapAppearingBlocks extends Trap {
 
     @Override
     public @NotNull List<Location> filter(@NotNull List<Location> list, @Nullable Object... objects) {
-
-        if (objects == null)
-            return list;
-
-        if (objects.length == 2)
-            return list;
-
-        if (!(objects[1] instanceof Material filterMaterial))
-            return list;
-
-        return list.stream()
-                .filter((location) -> location.getBlock().getType() == filterMaterial)
-                .toList();
-
+        return list;
     }
 
     @Override

--- a/core/src/main/java/pl/mrstudios/deathrun/arena/trap/impl/TrapDisappearingBlocks.java
+++ b/core/src/main/java/pl/mrstudios/deathrun/arena/trap/impl/TrapDisappearingBlocks.java
@@ -6,6 +6,7 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.data.BlockData;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import pl.mrstudios.deathrun.api.arena.trap.annotations.Serializable;
 import pl.mrstudios.deathrun.arena.trap.Trap;
 
@@ -54,7 +55,10 @@ public class TrapDisappearingBlocks extends Trap {
     }
 
     @Override
-    public @NotNull List<Location> filter(@NotNull List<Location> list, Object... objects) {
+    public @NotNull List<Location> filter(@NotNull List<Location> list, @Nullable Object... objects) {
+
+        if (objects == null)
+            return list;
 
         if (objects.length == 0)
             return list;

--- a/core/src/main/java/pl/mrstudios/deathrun/builder/ItemBuilder.java
+++ b/core/src/main/java/pl/mrstudios/deathrun/builder/ItemBuilder.java
@@ -7,13 +7,11 @@ import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.serializer.bungeecord.BungeeComponentSerializer;
 import net.md_5.bungee.api.chat.BaseComponent;
 import org.bukkit.Material;
-import org.bukkit.craftbukkit.v1_16_R3.block.impl.CraftSkullPlayer;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
 
-import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;

--- a/core/src/main/java/pl/mrstudios/deathrun/builder/ItemBuilder.java
+++ b/core/src/main/java/pl/mrstudios/deathrun/builder/ItemBuilder.java
@@ -1,5 +1,6 @@
 package pl.mrstudios.deathrun.builder;
 
+import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.serializer.bungeecord.BungeeComponentSerializer;
 import net.md_5.bungee.api.chat.BaseComponent;
@@ -31,7 +32,7 @@ public class ItemBuilder {
         if (this.itemMeta == null)
             return this;
 
-        this.itemMeta.setDisplayNameComponent(this.removeItalic(bungeeComponentSerializer.serialize(miniMessage.deserialize(name))));
+        this.itemMeta.setDisplayNameComponent(bungeeComponentSerializer.serialize(miniMessage.deserialize(name).decoration(TextDecoration.ITALIC, false)));
         return this;
     }
 
@@ -44,8 +45,8 @@ public class ItemBuilder {
 
         lore.stream()
                 .map(miniMessage::deserialize)
+                .map((component) -> component.decoration(TextDecoration.ITALIC, false))
                 .map(bungeeComponentSerializer::serialize)
-                .map(this::removeItalic)
                 .forEach(components::add);
 
         this.itemMeta.setLoreComponents(components);
@@ -67,17 +68,8 @@ public class ItemBuilder {
 
         if (this.itemMeta != null)
             this.itemStack.setItemMeta(this.itemMeta);
-        
+
         return this.itemStack;
-
-    }
-
-    protected BaseComponent[] removeItalic(BaseComponent[] components) {
-
-        for (BaseComponent component : components)
-            component.setItalic(false);
-
-        return components;
 
     }
 

--- a/core/src/main/java/pl/mrstudios/deathrun/builder/ItemBuilder.java
+++ b/core/src/main/java/pl/mrstudios/deathrun/builder/ItemBuilder.java
@@ -1,20 +1,15 @@
 package pl.mrstudios.deathrun.builder;
 
-import com.destroystokyo.paper.profile.PlayerProfile;
-import com.destroystokyo.paper.profile.ProfileProperty;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.serializer.bungeecord.BungeeComponentSerializer;
 import net.md_5.bungee.api.chat.BaseComponent;
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.inventory.meta.SkullMeta;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 public class ItemBuilder {
 
@@ -32,11 +27,18 @@ public class ItemBuilder {
     }
 
     public ItemBuilder name(String name) {
+
+        if (this.itemMeta == null)
+            return this;
+
         this.itemMeta.setDisplayNameComponent(this.removeItalic(bungeeComponentSerializer.serialize(miniMessage.deserialize(name))));
         return this;
     }
 
     public ItemBuilder lore(List<String> lore) {
+
+        if (this.itemMeta == null)
+            return this;
 
         List<BaseComponent[]> components = new ArrayList<>();
 
@@ -53,13 +55,21 @@ public class ItemBuilder {
     }
 
     public ItemBuilder itemFlag(ItemFlag... itemFlags) {
+
+        if (this.itemMeta == null)
+            return this;
+
         this.itemMeta.addItemFlags(itemFlags);
         return this;
     }
 
     public ItemStack build() {
-        this.itemStack.setItemMeta(this.itemMeta);
+
+        if (this.itemMeta != null)
+            this.itemStack.setItemMeta(this.itemMeta);
+        
         return this.itemStack;
+
     }
 
     protected BaseComponent[] removeItalic(BaseComponent[] components) {

--- a/core/src/main/java/pl/mrstudios/deathrun/builder/ItemBuilder.java
+++ b/core/src/main/java/pl/mrstudios/deathrun/builder/ItemBuilder.java
@@ -1,16 +1,23 @@
 package pl.mrstudios.deathrun.builder;
 
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.properties.Property;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.serializer.bungeecord.BungeeComponentSerializer;
 import net.md_5.bungee.api.chat.BaseComponent;
 import org.bukkit.Material;
+import org.bukkit.craftbukkit.v1_16_R3.block.impl.CraftSkullPlayer;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.SkullMeta;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 public class ItemBuilder {
 
@@ -62,6 +69,35 @@ public class ItemBuilder {
 
         this.itemMeta.addItemFlags(itemFlags);
         return this;
+    }
+
+    public ItemBuilder texture(String texture) {
+
+        if (texture == null)
+            return this;
+
+        if (this.itemMeta == null)
+            return this;
+
+        if (!(this.itemMeta instanceof SkullMeta skullMeta))
+            return this;
+
+        GameProfile gameProfile = new GameProfile(UUID.randomUUID(), "Player");
+
+        gameProfile.getProperties().put("textures", new Property("textures", texture));
+
+        try {
+
+            Method method = skullMeta.getClass().getDeclaredMethod("setProfile", GameProfile.class);
+            if (!method.isAccessible())
+                method.setAccessible(true);
+
+            method.invoke(skullMeta, gameProfile);
+
+        } catch (Exception ignored) {}
+
+        return this;
+
     }
 
     public ItemStack build() {

--- a/core/src/main/java/pl/mrstudios/deathrun/command/CommandDeathRun.java
+++ b/core/src/main/java/pl/mrstudios/deathrun/command/CommandDeathRun.java
@@ -97,7 +97,7 @@ public class CommandDeathRun {
                 "<reset> <b>*</b> <white>/deathrun setup setwaitinglobby",
                 "<reset> <b>*</b> <white>/deathrun setup setstartbarrier (material)",
                 "<reset> <b>*</b> <white>/deathrun setup addspawn <death/runner>",
-                "<reset> <b>*</b> <white>/deathrun setup addtrap <type> (material)",
+                "<reset> <b>*</b> <white>/deathrun setup addtrap <type> (objects)",
                 "<reset> <b>*</b> <white>/deathrun setup addcheckpoint",
                 "<reset> <b>*</b> <white>/deathrun setup addteleport",
                 "<reset> <b>*</b> <white>/deathrun setup save",
@@ -161,6 +161,12 @@ public class CommandDeathRun {
     @Permission("mrstudios.command.deathrun.setup")
     public void addTrap(@Context Player player, @Arg("type") String type, @Arg("material") Material material) {
         this.trap(player, type, material);
+    }
+
+    @Execute(name = "setup addtrap")
+    @Permission("mrstudios.command.deathrun.setup")
+    public void addTrap(@Context Player player, @Arg("type") String type, @Arg("material") Material material, @Arg("material") Material anotherMaterial) {
+        this.trap(player, type, material, material);
     }
 
     @Execute(name = "setup setname")
@@ -295,7 +301,9 @@ public class CommandDeathRun {
                 Material.CRIMSON_BUTTON,
                 Material.JUNGLE_BUTTON,
                 Material.SPRUCE_BUTTON,
-                Material.WARPED_BUTTON
+                Material.WARPED_BUTTON,
+                Material.POLISHED_BLACKSTONE_BUTTON,
+                Material.DARK_OAK_BUTTON
         ).noneMatch((button) -> target.getType().equals(button))) {
             this.message(player, "<reset> <dark_red><b>*</b> <red>You must look at button that is activating trap.");
             return;

--- a/core/src/main/java/pl/mrstudios/deathrun/command/CommandDeathRun.java
+++ b/core/src/main/java/pl/mrstudios/deathrun/command/CommandDeathRun.java
@@ -163,12 +163,6 @@ public class CommandDeathRun {
         this.trap(player, type, material);
     }
 
-    @Execute(name = "setup addtrap")
-    @Permission("mrstudios.command.deathrun.setup")
-    public void addTrap(@Context Player player, @Arg("type") String type, @Arg("material") Material material, @Arg("material") Material anotherMaterial) {
-        this.trap(player, type, material, material);
-    }
-
     @Execute(name = "setup setname")
     @Permission("mrstudios.command.deathrun.setup")
     public void setName(@Context Player player, @Arg("name") String name) {

--- a/core/src/main/java/pl/mrstudios/deathrun/config/impl/PluginConfiguration.java
+++ b/core/src/main/java/pl/mrstudios/deathrun/config/impl/PluginConfiguration.java
@@ -86,11 +86,13 @@ public class PluginConfiguration extends OkaeriConfig {
                     10,
                     new BoosterItem(
                             "<green>Booster <gray>(Right Click)",
-                            Material.FEATHER
+                            Material.FEATHER,
+                            null
                     ),
                     new BoosterItem(
                             "<red>Booster <gray>(<delay> seconds)",
-                            Material.FEATHER
+                            Material.FEATHER,
+                            null
                     ),
                     Direction.FORWARD,
                     Sound.ENTITY_BLAZE_AMBIENT

--- a/core/src/main/java/pl/mrstudios/deathrun/config/serializer/BoosterItemSerializer.java
+++ b/core/src/main/java/pl/mrstudios/deathrun/config/serializer/BoosterItemSerializer.java
@@ -13,15 +13,20 @@ public class BoosterItemSerializer implements ObjectSerializer<IBoosterItem> {
 
     @Override
     public void serialize(@NonNull IBoosterItem object, @NonNull SerializationData data, @NonNull GenericsDeclaration generics) {
+
         data.add("name", object.name());
         data.add("material", object.material());
+        if (object.texture() != null)
+            data.add("texture", object.texture());
+
     }
 
     @Override
     public IBoosterItem deserialize(@NonNull DeserializationData data, @NonNull GenericsDeclaration generics) {
         return new BoosterItem(
                 data.get("name", String.class),
-                data.get("material", Material.class)
+                data.get("material", Material.class),
+                (data.containsKey("texture")) ? data.get("texture", String.class) : null
         );
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 
     <groupId>pl.mrstudios.deathrun</groupId>
     <artifactId>deathrun-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
**ADDED:**
- Added booster cooldown in item amount.
- Added booster textures for heads.

**FIXED:**
- Fixed item names being italic.
- Fixed booster not removing from inventory after finished run.
- Fixed multiple boosters is not working with one item type.
- Fixed exceptions while booster item is air.
- Fixed `Disappearing Blocks` trap is removing all blocks in region.